### PR TITLE
port support for templating variables from teleport

### DIFF
--- a/cstrings/domain.go
+++ b/cstrings/domain.go
@@ -1,0 +1,19 @@
+package cstrings
+
+import (
+	"regexp"
+	"strings"
+)
+
+// IsValidDomainName is a primitive domain name checker
+// very relaxed and does not conform to spec
+func IsValidDomainName(v string) bool {
+	if !regexp.MustCompile("^[a-zA-Z0-9.-]+$").MatchString(v) {
+		return false
+	}
+	values := strings.Split(v, ".")
+	if len(values) < 2 || values[0] == "" {
+		return false
+	}
+	return true
+}

--- a/cstrings/split_test.go
+++ b/cstrings/split_test.go
@@ -49,3 +49,24 @@ func (s *USuite) TestSplit(c *C) {
 		c.Assert(out, DeepEquals, t.expect, comment)
 	}
 }
+
+func (s *USuite) TestDomain(c *C) {
+	tcs := []struct {
+		name     string
+		expected bool
+	}{
+		{name: "domain.com", expected: true},
+		{name: "domain com", expected: false},
+		{name: "A-z.com", expected: true},
+		{name: " ", expected: false},
+		{name: ".", expected: false},
+	}
+
+	for i, t := range tcs {
+		comment := Commentf(
+			"test case #%v: name: %v expected %v",
+			i, t.name, t.expected)
+		valid := IsValidDomainName(t.name)
+		c.Assert(valid, Equals, t.expected, comment)
+	}
+}

--- a/tpl.go
+++ b/tpl.go
@@ -1,0 +1,87 @@
+package configure
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+	"text/template"
+
+	"github.com/gravitational/configure/cstrings"
+	"github.com/gravitational/trace"
+)
+
+func renderTemplate(data []byte) ([]byte, error) {
+	t := template.New("tpl")
+	c, err := newCtx()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	t.Funcs(map[string]interface{}{
+		"env":  c.Env,
+		"file": c.File,
+	})
+	t, err = t.Parse(string(data))
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	buf := &bytes.Buffer{}
+	if err := t.Execute(buf, nil); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return buf.Bytes(), nil
+}
+
+func newCtx() (*ctx, error) {
+	values := os.Environ()
+	c := &ctx{
+		env: make(map[string]string, len(values)),
+	}
+	for _, v := range values {
+		vals := strings.SplitN(v, "=", 2)
+		if len(vals) != 2 {
+			return nil, trace.Errorf("failed to parse variable: '%v'", v)
+		}
+		c.env[vals[0]] = vals[1]
+	}
+	return c, nil
+}
+
+type ctx struct {
+	env map[string]string
+}
+
+func (c *ctx) File(path string) (string, error) {
+	o, err := ioutil.ReadFile(path)
+	if err != nil {
+		return "", trace.Wrap(err, fmt.Sprintf("reading file: %v", path))
+	}
+	return string(o), nil
+}
+
+func (c *ctx) Env(key string) (string, error) {
+	v, ok := c.env[key]
+	if !ok {
+		return "", trace.Errorf("environment variable '%v' is not set", key)
+	}
+	values := cstrings.SplitComma(v)
+	out := make([]string, len(values))
+	for i, p := range values {
+		out[i] = quoteYAML(p)
+	}
+	return strings.Join(out, ","), nil
+}
+
+func quoteYAML(val string) string {
+	if len(val) == 0 {
+		return val
+	}
+	if strings.HasPrefix(val, "'") && strings.HasSuffix(val, "'") {
+		return val
+	}
+	if strings.ContainsAny(val, ":") {
+		return "'" + val + "'"
+	}
+	return val
+}

--- a/yaml_test.go
+++ b/yaml_test.go
@@ -16,6 +16,8 @@ limitations under the License.
 package configure
 
 import (
+	"os"
+
 	"github.com/gravitational/configure/test"
 	"github.com/gravitational/log"
 	. "gopkg.in/check.v1"
@@ -46,4 +48,18 @@ nested:
 	err := ParseYAML([]byte(raw), &cfg)
 	c.Assert(err, IsNil)
 	s.CheckVariables(c, &cfg)
+}
+
+func (s *YAMLSuite) TestParseTemplate(c *C) {
+	type config struct {
+		Data string `yaml:"data"`
+	}
+	os.Setenv("TEST_VAR1", "test var 1")
+
+	raw := `data: {{env "TEST_VAR1"}}`
+
+	var cfg config
+	err := ParseYAML([]byte(raw), &cfg, EnableTemplating())
+	c.Assert(err, IsNil)
+	c.Assert(cfg.Data, Equals, "test var 1")
 }


### PR DESCRIPTION
Adds functional argument `EnableTemplating` to `ParseYAML` that allows to treat configuration file as a template, for example:

```yaml
data: {{env "TEST_VAR1"}}
```
