### PR TITLE
Empty map should not be set as nil

### DIFF
--- a/jsonschema/schema.go
+++ b/jsonschema/schema.go
@@ -115,9 +115,6 @@ func setDefaults(ischema interface{}, ivars interface{}) interface{} {
 			}
 			out[key] = defval
 		}
-		if len(out) == 0 {
-			return nil
-		}
 		return out
 	case "array":
 		var vars []interface{}

--- a/jsonschema/schema_test.go
+++ b/jsonschema/schema_test.go
@@ -47,7 +47,7 @@ func (s *SchemaSuite) TestDefaults(c *C) {
 		},
 		{
 			schema: `{
-                 "type": "object", 
+                 "type": "object",
                  "properties": {
                     "value": {"type": "string", "default": "hello"},
                     "value2": {"type": "string"}
@@ -60,9 +60,9 @@ func (s *SchemaSuite) TestDefaults(c *C) {
 		},
 		{
 			schema: `{
-                 "type": "array", 
+                 "type": "array",
                  "items": {
-                    "type": "string", 
+                    "type": "string",
                     "default": "hello"
                  }
             }`,
@@ -71,9 +71,9 @@ func (s *SchemaSuite) TestDefaults(c *C) {
 		},
 		{
 			schema: `{
-                 "type": "array", 
+                 "type": "array",
                  "items": {
-                    "type": "object", 
+                    "type": "object",
                     "properties": {
                        "val": {"type": "string", "default": "hello"}
                     }
@@ -84,7 +84,7 @@ func (s *SchemaSuite) TestDefaults(c *C) {
 		},
 		{
 			schema: `{
-                 "type": "object", 
+                 "type": "object",
                  "default": {},
                  "properties": {
                      "values": {
@@ -105,12 +105,12 @@ func (s *SchemaSuite) TestDefaults(c *C) {
 		},
 		{
 			schema: `{
-                 "type": "object", 
+                 "type": "object",
                  "properties": {
                      "values": {
-                        "type": "array", 
+                        "type": "array",
                          "items": {
-                             "type": "object", 
+                             "type": "object",
                              "properties": {
                                 "val": {"type": "string", "default": "hello"}
                              }
@@ -130,6 +130,16 @@ func (s *SchemaSuite) TestDefaults(c *C) {
 					},
 				},
 			},
+		},
+		{
+			schema: `{
+                 "type": "object",
+                 "properties": {
+                     "value": {"type": "string"}
+                 }
+            }`,
+			input:  map[string]interface{}{},
+			output: map[string]interface{}{},
 		},
 	}
 	for i, tc := range tcs {


### PR DESCRIPTION
The `setDefaults` method used to set empty maps as `nil` which led to immediate subsequent failure during `j.schema.Validate` - because the schema expects an object but gets null.