### PR TITLE
Better implementation of IsUnixUsername

### DIFF
--- a/cstrings/split_test.go
+++ b/cstrings/split_test.go
@@ -99,10 +99,15 @@ func (s *USuite) TestUser(c *C) {
 		name     string
 		expected bool
 	}{
-		{name: "admin", expected: true},
-		{name: "centos", expected: true},
+		{name: "Admin", expected: true},
+		{name: "ce-nt.os", expected: true},
 		{name: "ubuntu-2", expected: true},
+		{name: "", expected: false},
 		{name: " ", expected: false},
+		{name: "-ab", expected: false},
+		{name: "a/b", expected: false},
+		{name: "a\tb", expected: false},
+		{name: "a\nb", expected: false},
 		{name: " ubuntu ?", expected: false},
 		{name: strings.Repeat("a", 33), expected: false},
 	}

--- a/cstrings/user.go
+++ b/cstrings/user.go
@@ -1,15 +1,35 @@
 package cstrings
 
 import (
-	"regexp"
+	"strings"
+	"unicode"
 )
 
-var usersRe = regexp.MustCompile("^[a-z_][a-z0-9_-]*$")
+const (
+	maxUsernameLen = 32
+)
 
-// IsValidUnixUser returns true if passed string appears to
+// IsValidUnixUser returns true if passed string can be used
+// to create a valid UNIX user
 func IsValidUnixUser(u string) bool {
-	if len(u) > 32 {
+	/* See http://www.unix.com/man-page/linux/8/useradd:
+
+		On Debian, the only constraints are that usernames must neither start with a dash ('-')
+	    nor contain a colon (':') or a whitespace (space: ' ', end of line: '\n', tabulation:
+	    '\t', etc.). Note that using a slash ('/') may break the default algorithm for the
+	    definition of the user's home directory.
+
+	*/
+	if len(u) > maxUsernameLen || len(u) == 0 || u[0] == '-' {
 		return false
 	}
-	return usersRe.MatchString(u)
+	if strings.ContainsAny(u, ":/") {
+		return false
+	}
+	for _, r := range u {
+		if unicode.IsSpace(r) || unicode.IsControl(r) {
+			return false
+		}
+	}
+	return true
 }


### PR DESCRIPTION
### Problem

Telecast logs are full of error messages like:

`dean.carpenter is not a valid unix username`
`Voyga is not a valid unix username`

Also there's Teleport bug:
https://github.com/gravitational/teleport/issues/517

### Changes

The new implementation follows Debian guidelines