### PR TITLE
added `description` to cli commands

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -82,7 +82,12 @@ func setupApp(app *kingpin.Application, v reflect.Value) error {
 		if !field.CanAddr() {
 			continue
 		}
-		f := app.Flag(cliFlag, cliFlag)
+		cliFlagDescription := structField.Tag.Get("description")
+		if cliFlagDescription == "" {
+			cliFlagDescription = cliFlag		
+		}
+		
+		f := app.Flag(cliFlag, cliFlagDescription)
 		fieldPtr := field.Addr().Interface()
 		if setter, ok := fieldPtr.(CLISetter); ok {
 			f.SetValue(&cliValue{setter: setter})


### PR DESCRIPTION
allowing users to defined `description` for cli flags.
```golang
type Config struct {
  StrFlag1 string `cli:"flag1" description:"this is a test description for the cli flag"`
}
```